### PR TITLE
Implement Fix for Bib usage with Pandoc 2.11+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ pdf:
 	pandoc "$(INPUTDIR)"/*.md \
 	-o "$(OUTPUTDIR)/thesis.pdf" \
 	-H "$(STYLEDIR)/preamble.tex" \
+	-C \
 	--template="$(STYLEDIR)/template.tex" \
 	--bibliography="$(BIBFILE)" 2>pandoc.log \
 	--csl="$(STYLEDIR)/ref_format.csl" \

--- a/style/template.tex
+++ b/style/template.tex
@@ -154,6 +154,32 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newlength{\cslentryspacingunit} % times entry-spacing
+\setlength{\cslentryspacingunit}{\parskip}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry sp
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1
+  \let\oldpar\par
+  \def\par{\hangindent=\cslhangindent\oldpar}
+  \fi
+  % set entry spacing
+  \setlength{\parskip}{#2\cslentryspacingunit}
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+$endif$
+
 % References; This whole block should be the last before \begin{document}
 \usepackage[hyphens]{url} % enables line breaks in urls at hyphens
 \ifxetex


### PR DESCRIPTION
Mir ist aufgefallen das in der Aktuellen Version das Literaturverzeichnis nicht mehr automatisch generiert wird. Das sollte es fixen es gab eine erweiterung die in der Template.tex implementiert werden muss wenn man Pandoc 2.11+ Verwendet. 
Was mir auch aufgefallen ist wenn man unter Windows arbeitet und nicht unter Linux funktioniert das Makefile nicht da muss ein bisschen was angepasst werden, da unter windows keine Wildcars funktionieren. 